### PR TITLE
Fixes for non snap enviorments. Portability for ssh check. Portability for bash

### DIFF
--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -1,9 +1,11 @@
+#!/usr/bin/env bash
+
 function initImageVars {
     if [ "$(uname -s)" == "Linux" ]; then
         if [ "$ARCH" == "arm64" ]; then
             EFI_1="$SNAP/usr/share/qemu/edk2-aarch64-code.fd"
             EFI_2="$SNAP/usr/share/qemu/edk2-arm-vars.fd"
-            if [ "$SNAP" == "" ]; then
+            if [ -n "$SNAP" ]; then
                 QEMU=qemu-system-aarch64
             else
                 QEMU="$SNAP/usr/bin/qemu-system-aarch64"
@@ -15,7 +17,7 @@ function initImageVars {
                 -device AC97 \
                 -serial mon:stdio"
         else
-            if [ "$SNAP" == "" ]; then
+            if [ -n "$SNAP" ]; then
                 QEMU=qemu-system-x86_64
             else
                 QEMU="$SNAP/usr/bin/qemu-system-x86_64"

--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -5,7 +5,7 @@ function initImageVars {
         if [ "$ARCH" == "arm64" ]; then
             EFI_1="$SNAP/usr/share/qemu/edk2-aarch64-code.fd"
             EFI_2="$SNAP/usr/share/qemu/edk2-arm-vars.fd"
-            if [ -n "$SNAP" ]; then
+            if [ -z "$SNAP" ]; then
                 QEMU=qemu-system-aarch64
             else
                 QEMU="$SNAP/usr/bin/qemu-system-aarch64"
@@ -17,7 +17,7 @@ function initImageVars {
                 -device AC97 \
                 -serial mon:stdio"
         else
-            if [ -n "$SNAP" ]; then
+            if [ -z "$SNAP" ]; then
                 QEMU=qemu-system-x86_64
             else
                 QEMU="$SNAP/usr/bin/qemu-system-x86_64"

--- a/scripts/mounts.sh
+++ b/scripts/mounts.sh
@@ -59,7 +59,7 @@ function copySettingsIntoImage {
 
 function startVirtiofsd {
     # Return immediately in non-Snap environments
-    if [ -n "$SNAP" ]; then
+    if [ -z "$SNAP" ]; then
         return
     fi
     VIRTIOFS_SOCK="$SNAP_USER_DATA/$NAME-vhost-fs.sock"

--- a/scripts/mounts.sh
+++ b/scripts/mounts.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 function initSettingsVars {
     if [ "$(uname -s)" == "Darwin" ]; then
         SETTINGS_FILE="$DATA_ROOT/sshd/settings.dmg"
@@ -57,7 +59,7 @@ function copySettingsIntoImage {
 
 function startVirtiofsd {
     # Return immediately in non-Snap environments
-    if [ "$SNAP" == "" ]; then
+    if [ -n "$SNAP" ]; then
         return
     fi
     VIRTIOFS_SOCK="$SNAP_USER_DATA/$NAME-vhost-fs.sock"

--- a/scripts/prerequisites.sh
+++ b/scripts/prerequisites.sh
@@ -11,7 +11,7 @@ if [ "$HOST_OS" == "Darwin" ]; then
     brew install coreutils
 elif [ "$HOST_OS" == "Linux" ]; then
     # Only necessary in non-Snap environments
-    if [ "$SNAP" == "" ]; then
+    if [ -n "$SNAP" ]; then
         sudo snap install --edge qemu-ut-pdk
         sudo snap connect qemu-ut-pdk:kvm
         # Heck, throw a group check in there too

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,7 +2,7 @@
 
 function warnMissingPlugs {
     # Only run in Snap environments
-    if [ -n "$SNAP" ]; then
+    if [ -z "$SNAP" ]; then
         return
     fi
 
@@ -98,16 +98,11 @@ function tryInstallSshd {
 
 function checkSsh {
     # Only required on non-Snap Linux
-    if [ "$(uname -s)" == "Linux" ] && [ "$SNAP_USER_COMMON" == "" ]; then
-        case $(lsb_release -si) in
-            Fedora)
-                IS_INSTALLED=$(systemctl status sshd 1&>/dev/null && echo 1 || echo 0)
-                ;;
-            *)
-                IS_INSTALLED=$(systemctl status ssh 1&>/dev/null && echo 1 || echo 0)
-                ;;
-        esac
-        if [ "$IS_INSTALLED" != "1" ]; then
+    if [ "$(uname -s)" == "Linux" ] && [ -z "$SNAP" ]; then
+        # Check if ssh or sshd is running and set the variable IS_INSTALLED to 1 if it is using pgrep
+        pgrep -f "ssh" > /dev/null && IS_INSTALLED=1 || IS_INSTALLED=0
+        
+        if [ "$IS_INSTALLED" -ne 1 ]; then
             echo "WARNING: The OpenSSH server seems to be missing or not activated, please install it using your package manager."
             while true; do
                 read -p "Would you like to do that automatically now [y/n]? " yn
@@ -151,7 +146,7 @@ function setup {
 
     # Snap is done here, just needs ta check inside ya sshd settings
     # (on other platforms)
-    if [ -n "$SNAP" ]; then
+    if [ -z "$SNAP" ]; then
         if [ -f "$DATA_ROOT/sshd/id_rsa" ]; then
             rm "$DATA_ROOT/sshd/id_rsa"
         fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,6 +1,8 @@
+#!/usr/bin/env bash
+
 function warnMissingPlugs {
     # Only run in Snap environments
-    if [ "$SNAP" == "" ]; then
+    if [ -n "$SNAP" ]; then
         return
     fi
 
@@ -149,7 +151,7 @@ function setup {
 
     # Snap is done here, just needs ta check inside ya sshd settings
     # (on other platforms)
-    if [ "$SNAP" == "" ]; then
+    if [ -n "$SNAP" ]; then
         if [ -f "$DATA_ROOT/sshd/id_rsa" ]; then
             rm "$DATA_ROOT/sshd/id_rsa"
         fi

--- a/ubuntu-touch-pdk
+++ b/ubuntu-touch-pdk
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Fixes issues with this not running on non snap environments 
closes #39 

Removes the use of lsb_release since that is not a universal package included in every distro. Replaced it with a pgrep for ssh to see if the ssh service is running.

Replaces /bin/bash with a more universal option of /usr/bin/env bash as /bin/bash doesnt always exists in every distro such as for nixos.

I am still unable to run this in nixos due to Property 'virtio-vga.virgl' not found and removing 
> ,virgl=on

from 

> -device virtio-vga,virgl=on

showing a black screen and removing that section all together and the gl=on a bit after shows me just a prompt screen terminal without he gui.