### PR TITLE
Add support for 24.04-based Ubuntu Touch

### DIFF
--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -20,7 +20,10 @@ function initCommonVars {
     fi
 
     DEFAULT_DATA_ROOT="$CONFIG_ROOT/data"
-    IMG_NAME="ubuntu-touch-pdk-img-$ARCH.raw"
+    case ${RELEASE} in
+        focal) IMG_NAME="ubuntu-touch-pdk-img-$ARCH.raw" ;;
+        noble) IMG_NAME="ubuntu-touch-pdk-img-devel-$ARCH.raw" ;;
+    esac
     PULL_IMG_NAME="${IMG_NAME}.xz"
     # The CI job name happens to have "arm64" in it. However, it now contains
     # images for all architectures.

--- a/ubuntu-touch-pdk
+++ b/ubuntu-touch-pdk
@@ -30,13 +30,16 @@ RUN=no
 PRINT_VERSION=no
 NAME=default
 ARCH="$HOST_ARCH"
+RELEASE=focal
 
 function printHelp {
     printf "usage: %s <options> <command> [<command> ..]\n\n" "$0"
     printf "Options:\n"
-    printf "\t-a=|--arch=: Architecture override (optional, defaults to '%s')\n" "$HOST_ARCH"
-    printf "\t             Possible values: arm64, amd64\n"
-    printf "\t-n=|--name=: Name of the image (optional, defaults to 'default')\n\n"
+    printf "\t-a=|--arch=:    Architecture override (optional, defaults to '%s')\n" "$HOST_ARCH"
+    printf "\t                Possible values: arm64, amd64\n"
+    printf "\t-r=|--release=: Ubuntu Touch release override (optional, defaults to 'focal')\n"
+    printf "\t                Possible values: noble, focal\n"
+    printf "\t-n=|--name=:    Name of the image (optional, defaults to 'default')\n\n"
     printf "Commands:\n"
     printf "\tsetup: Host OS preparations (recommended for first-time use)\n"
     printf "\tclear: Clean up all images\n"
@@ -84,6 +87,10 @@ while [[ $# -gt 0 ]]; do
         ;;
         "-a="*|"--arch="*)
             ARCH="${arg#*=}"
+            shift
+        ;;
+        "-r="*|"--release="*)
+            RELEASE="${arg#*=}"
             shift
         ;;
         -h|--help)
@@ -134,6 +141,12 @@ source "$SCRIPTPATH/scripts/images.sh"
 source "$SCRIPTPATH/scripts/mounts.sh"
 initImageVars
 initSettingsVars
+
+if [ -z "$IMG_NAME" ]; then
+    printf "Invalid release '%s' specified.\n" "$RELEASE"
+    printHelp
+    exit 1
+fi
 
 if [ -z "$DATA_ROOT" ] || [ "$SETUP" == "yes" ]; then
     # Warn when something's not right


### PR DESCRIPTION
24.04 doesn't boot to UI or allow login as `root:root` as per the README so I've left `focal` as the default release still for now.