### PR TITLE
Resolved issue with missing seabios files 

### DIFF
--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -10,6 +10,7 @@ function getQemuVersion {
 
 function initImageVars {
     if [ "$(uname -s)" == "Linux" ]; then
+        QEMU_DATA_DIR=""
         if [ "$ARCH" == "arm64" ]; then
             SUBDIR="qemu"
             EFI_SUBDIR="qemu"
@@ -21,8 +22,10 @@ function initImageVars {
             EFI_2="$SNAP/usr/share/$EFI_SUBDIR/$EFI_VARS"
             if [ -z "$SNAP" ]; then
                 QEMU=qemu-system-aarch64
+                QEMU_DATA_DIR=/usr/share/qemu
             else
                 QEMU="$SNAP/usr/bin/qemu-system-aarch64"
+                QEMU_DATA_DIR="$SNAP/usr/share/qemu"
             fi
             QEMU_ARGS="\
                 -machine virt
@@ -34,8 +37,10 @@ function initImageVars {
         else
             if [ -z "$SNAP" ]; then
                 QEMU=qemu-system-x86_64
+                QEMU_DATA_DIR=/usr/share/qemu
             else
                 QEMU="$SNAP/usr/bin/qemu-system-x86_64"
+                QEMU_DATA_DIR="$SNAP/usr/share/qemu"
             fi
             QEMU_ARGS="\
                 -cpu host \
@@ -43,6 +48,10 @@ function initImageVars {
                 -device rtl8139,netdev=ethernet.0 \
                 -device AC97 \
                 -serial mon:stdio"
+        fi
+
+        if [ -n "$QEMU_DATA_DIR" ]; then
+            QEMU_ARGS="-L $QEMU_DATA_DIR $QEMU_ARGS"
         fi
 
         QEMU_ARGS="-display $GUI,gl=on $QEMU_ARGS"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,6 +56,10 @@ parts:
       source $CRAFT_PART_SRC/scripts/vars.sh
       craftctl set version="$VERSION"
       craftctl set grade="stable"
+      mkdir -p $SNAPCRAFT_PRIME/usr/share/qemu
+      if [ -d "$SNAPCRAFT_STAGE/usr/share/seabios" ]; then
+        cp -a $SNAPCRAFT_STAGE/usr/share/seabios/. $SNAPCRAFT_PRIME/usr/share/qemu/
+      fi
     organize:
       scripts: bin/scripts
       ubuntu-touch-pdk: bin/ubuntu-touch-pdk
@@ -72,6 +76,7 @@ parts:
       - ovmf
       - qemu-efi-aarch64
       - libfdt1
+      - seabios
   runner:
     after: [ pdk ]
     source: snap/local


### PR DESCRIPTION
Include SeaBIOS ROMs in snap and copy them into QEMU data directory.